### PR TITLE
Noetic support

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>tf2</depend>
   <depend>visualization_msgs</depend>
   <depend>image_transport</depend>
+  <depend>image_transport_plugins</depend>
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>opencv3</depend>

--- a/src/dnn_detect.cpp
+++ b/src/dnn_detect.cpp
@@ -48,6 +48,7 @@
 #include <list>
 #include <string>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 
 #include <thread>
 #include <mutex>


### PR DESCRIPTION
Hi there, just thought I'd pull request these two small changes I had to make to get a successful noetic build with docker.

The `image_transport_plugins` dep is required, for instance, for subscribing to compressed image topics.

The `boost/format.hpp` include is apparently something that became required from melodic onwards: https://github.com/jsk-ros-pkg/jsk_common/pull/1584.

For reference the Dockerfile I used to build for noetic is here: https://gist.github.com/tim-fan/c5f39f2d6a3258c21fe568d0e667c5f9

I've confirmed I can still build for kinetic with these changes applied.



