### PR TITLE
remove unused dependency on fiducial_msgs in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,6 @@
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>opencv3</depend>
-  <depend>fiducial_msgs</depend>
   <depend>dynamic_reconfigure</depend>
 
 </package>


### PR DESCRIPTION
Hello, as I'm about to mention in #8 , the `fiducial_msgs` dependency is an issue for supporting noetic, as it is not released for noetic. However, as far as I can tell the `fiducial_msgs` is not actually used in this package, so I recommend deleting it from package.xml, as per this pull request.