### PR TITLE
Remove opencv3 from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,6 @@
   <depend>image_transport_plugins</depend>
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>opencv3</depend>
   <depend>dynamic_reconfigure</depend>
 
 </package>


### PR DESCRIPTION
As discussed in #8 . The dependency on opencv3 is dropped, as this is not available in noetic, and the cv_bridge dependency pulls in working versions of opencv on both kinetic and noetic anyway.

Have tested in kinetic and noetic, confirmed I can build and run `dnn_detect.launch` in both instances.