### PR TITLE
dnn_images_test support opencv version 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,5 +83,6 @@ if(CATKIN_ENABLE_TESTING)
         add_rostest_gtest(dnn_images_test 
           test/dnn_images.test 
           test/dnn_images_test.cpp)
+        add_dependencies(dnn_images_test ${PROJECT_NAME}_generate_messages)
         target_link_libraries(dnn_images_test ${catkin_LIBRARIES} ${OpenCV_LIBS})
 endif()

--- a/test/dnn_images_test.cpp
+++ b/test/dnn_images_test.cpp
@@ -11,6 +11,11 @@
 
 #include <boost/thread/thread.hpp>
 
+#if CV_MAJOR_VERSION < 4
+    #define IMREAD_COLOR_MODE CV_LOAD_IMAGE_COLOR
+#else
+    #define IMREAD_COLOR_MODE cv::IMREAD_COLOR
+#endif
 
 class DnnImagesTest : public ::testing::Test {
 protected:
@@ -41,7 +46,7 @@ protected:
     boost::thread trig(&DnnImagesTest::trigger, this);
 
     sleep(1);
-    cv::Mat image = cv::imread(image_directory+file, CV_LOAD_IMAGE_COLOR);
+    cv::Mat image = cv::imread(image_directory+file, IMREAD_COLOR_MODE);
     sensor_msgs::ImagePtr msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8",
         image).toImageMsg();
     image_pub.publish(msg);


### PR DESCRIPTION
Hopefully the last pull request for #8 :smile: 

This allows the test to run in Noetic. The `imread` modes are different in opencv4 (noetic), so I `#define` them based on cv version. Let me know if there's a cleaner way of getting this working.

I also needed to add a dependency on message generation in `CMakeLists.txt`, perhaps because earlier builds have used `catkin_make` and I'm using `catkin build`.

For reference I'm testing with this Dockerfile: https://github.com/tim-fan/dockerfiles/blob/master/20200805_dnn_detect_noetic_support/Dockerfile. This builds successfully if I point it to use my fork. I also confirmed it still builds on kinetic.
 